### PR TITLE
feat(post): 实现帖子与分类和标签的关联功能及测试

### DIFF
--- a/backend/migrations/20250520163847_create_post_categories_table.sql
+++ b/backend/migrations/20250520163847_create_post_categories_table.sql
@@ -1,0 +1,31 @@
+-- backend/migrations/YYYYMMDDHHMMSS_create_post_categories_table.sql
+
+-- 创建 post_categories 表，用于帖子和分类之间的多对多关系
+CREATE TABLE post_categories
+(
+    post_id     UUID        NOT NULL,               -- 帖子ID，外键关联 posts 表的 id
+    category_id UUID        NOT NULL,               -- 分类ID，外键关联 categories 表的 id
+    assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), -- 关联创建时间，默认为当前时间
+
+    -- 复合主键，确保一个帖子不会多次关联同一个分类
+    PRIMARY KEY (post_id, category_id),
+
+    -- 外键约束：关联到 posts 表的 post_id
+    CONSTRAINT fk_post_categories_post
+        FOREIGN KEY (post_id)
+            REFERENCES posts (id)
+            ON DELETE CASCADE,                      -- 如果帖子被删除，则自动删除此关联记录
+
+    -- 外键约束：关联到 categories 表的 category_id
+    CONSTRAINT fk_post_categories_category
+        FOREIGN KEY (category_id)
+            REFERENCES categories (id)
+            ON DELETE CASCADE                       -- 如果分类被删除，则自动删除此关联记录
+);
+
+-- 可选索引：可以提高通过此表进行连接查询的性能
+-- 主键 (post_id, category_id) 已经创建了一个覆盖这两个列的索引。
+-- 如果经常单独通过 post_id 或 category_id 在此表中查询，可以考虑创建单独索引。
+-- 初期可以不加，根据后续性能分析决定是否添加。
+-- CREATE INDEX IF NOT EXISTS idx_post_categories_post_id ON post_categories(post_id);
+-- CREATE INDEX IF NOT EXISTS idx_post_categories_category_id ON post_categories(category_id);

--- a/backend/migrations/20250520163923_create_post_tags_table.sql
+++ b/backend/migrations/20250520163923_create_post_tags_table.sql
@@ -1,0 +1,28 @@
+-- backend/migrations/YYYYMMDDHHMMSS_create_post_tags_table.sql
+
+-- 创建 post_tags 表，用于帖子和标签之间的多对多关系
+CREATE TABLE post_tags
+(
+    post_id     UUID        NOT NULL,               -- 帖子ID，外键关联 posts 表的 id
+    tag_id      UUID        NOT NULL,               -- 标签ID，外键关联 tags 表的 id
+    assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), -- 关联创建时间，默认为当前时间
+
+    -- 复合主键，确保一个帖子不会多次关联同一个标签
+    PRIMARY KEY (post_id, tag_id),
+
+    -- 外键约束：关联到 posts 表的 post_id
+    CONSTRAINT fk_post_tags_post
+        FOREIGN KEY (post_id)
+            REFERENCES posts (id)
+            ON DELETE CASCADE,                      -- 如果帖子被删除，则自动删除此关联记录
+
+    -- 外键约束：关联到 tags 表的 tag_id
+    CONSTRAINT fk_post_tags_tag
+        FOREIGN KEY (tag_id)
+            REFERENCES tags (id)
+            ON DELETE CASCADE                       -- 如果标签被删除，则自动删除此关联记录
+);
+
+-- 可选索引 (原因同 post_categories 表)
+-- CREATE INDEX IF NOT EXISTS idx_post_tags_post_id ON post_tags(post_id);
+-- CREATE INDEX IF NOT EXISTS idx_post_tags_tag_id ON post_tags(tag_id);

--- a/backend/src/dtos/post.rs
+++ b/backend/src/dtos/post.rs
@@ -1,20 +1,29 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use crate::models::{Category, Tag};
 
-// 用于创建新文章的数据结构（DTO - Data Transfer Object）
+/// 用于创建新文章的数据结构（DTO - Data Transfer Object）
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreatePostPayload {
     pub title: String,
     pub content: String,
-    // 注意：创建时通常不需要 slug 和 published_at，slug 应自动生成，published_at 应为 None
+    // 帖子的分类 ID 列表 (Option<Vec<Uuid>> 表示可以不提供，或者提供一个空的 Vec)
+    pub category_ids: Option<Vec<Uuid>>,
+    pub tag_ids: Option<Vec<Uuid>>, // 帖子的标签 ID 列表
+                                    // 注意：创建时通常不需要 slug 和 published_at，slug 应自动生成，published_at 应为 None
 }
 
-// 用于更新文章的数据结构（DTO）
+/// 用于更新文章的数据结构（DTO）
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct UpdatePostPayload {
     pub title: Option<String>, // 使用 Option 表示可选更新
     pub content: Option<String>,
     pub slug: Option<String>,
+    // Option<Vec<Uuid>>: 如果是 None，则不更新此关联；
+    // 如果是 Some(Vec)，则将关联设置为该 Vec (可以是空 Vec 表示清除所有关联)
+    pub category_ids: Option<Vec<Uuid>>,
+    pub tag_ids: Option<Vec<Uuid>>,
     // 用于设置或更改发布时间
     pub published_at: Option<DateTime<Utc>>, // Option<Option<...>> 允许设置为 NULL
     // 明确的标志来指示是否要撤销发布 (将 published_at 置为 NULL)
@@ -23,3 +32,54 @@ pub struct UpdatePostPayload {
     pub unpublish: bool,
 }
 
+/// 用于在获取单个帖子详情时，同时返回帖子的基本信息及其关联的分类和标签信息
+#[derive(Debug,Serialize,Deserialize,Clone)]
+pub struct PostDetailDto{
+    // Post 模型中的字段
+    pub id: Uuid,
+    pub slug: String,
+    pub title: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
+    // 关联的分类信息
+    
+    // 关联的标签信息
+}
+
+/// 分类的简化 DTO,不想在 PostDetailDto 中暴露完整的 Category 模型
+#[derive(Debug,Serialize,Deserialize,Clone)]
+pub struct CategoryDto{
+    pub id: Uuid,
+    pub name: String,
+    pub slug: String,
+}
+
+impl From<Category> for CategoryDto{
+    fn from(category: Category) -> Self {
+        Self {
+            id: category.id,
+            name: category.name,
+            slug: category.slug,
+        }
+    }
+}
+
+/// 标签的简化 DTO
+#[derive(Debug,Serialize,Deserialize,Clone)]
+pub struct TagDto {
+    pub id: Uuid,
+    pub name: String,
+    pub slug: String,
+}
+
+impl From<Tag> for TagDto{
+    fn from(tag: Tag) -> Self {
+        Self {
+            id: tag.id,
+            name: tag.name,
+            slug: tag.slug,
+        }
+    }
+}

--- a/backend/src/dtos/post.rs
+++ b/backend/src/dtos/post.rs
@@ -1,7 +1,7 @@
+use crate::models::{Category, Tag};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::models::{Category, Tag};
 
 /// 用于创建新文章的数据结构（DTO - Data Transfer Object）
 #[derive(Debug, Deserialize, Serialize)]
@@ -33,8 +33,8 @@ pub struct UpdatePostPayload {
 }
 
 /// 用于在获取单个帖子详情时，同时返回帖子的基本信息及其关联的分类和标签信息
-#[derive(Debug,Serialize,Deserialize,Clone)]
-pub struct PostDetailDto{
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PostDetailDto {
     // Post 模型中的字段
     pub id: Uuid,
     pub slug: String,
@@ -44,19 +44,20 @@ pub struct PostDetailDto{
     pub updated_at: DateTime<Utc>,
     pub published_at: Option<DateTime<Utc>>,
     // 关联的分类信息
-    
+    pub categories: Option<Vec<CategoryDto>>,
     // 关联的标签信息
+    pub tags: Option<Vec<TagDto>>,
 }
 
 /// 分类的简化 DTO,不想在 PostDetailDto 中暴露完整的 Category 模型
-#[derive(Debug,Serialize,Deserialize,Clone)]
-pub struct CategoryDto{
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CategoryDto {
     pub id: Uuid,
     pub name: String,
     pub slug: String,
 }
 
-impl From<Category> for CategoryDto{
+impl From<Category> for CategoryDto {
     fn from(category: Category) -> Self {
         Self {
             id: category.id,
@@ -67,14 +68,14 @@ impl From<Category> for CategoryDto{
 }
 
 /// 标签的简化 DTO
-#[derive(Debug,Serialize,Deserialize,Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TagDto {
     pub id: Uuid,
     pub name: String,
     pub slug: String,
 }
 
-impl From<Tag> for TagDto{
+impl From<Tag> for TagDto {
     fn from(tag: Tag) -> Self {
         Self {
             id: tag.id,

--- a/backend/src/handlers/post.rs
+++ b/backend/src/handlers/post.rs
@@ -18,8 +18,8 @@ pub async fn create_post_handler(
     Json(payload): Json<CreatePostPayload>, // 从请求体解析 JSON
 ) -> Result<impl IntoResponse, ApiError> {
     // 返回 Result<impl IntoResponse, ApiError>
-    let post = state.post_service.create_post(payload).await?; //调用服务层方法
-    Ok((StatusCode::CREATED, Json(post))) // 成功返回 201 CREATED 和 JSON 数据
+    let post_detail = state.post_service.create_post(payload).await?; //调用服务层方法
+    Ok((StatusCode::CREATED, Json(post_detail))) // 成功返回 201 CREATED 和 JSON 数据
 }
 
 // 获取文章列表处理器
@@ -38,11 +38,11 @@ pub async fn get_post_handler(
     Path(id_or_slug): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
     // 尝试解析为UUID
-    let post = match Uuid::parse_str(&id_or_slug) {
+    let post_detail = match Uuid::parse_str(&id_or_slug) {
         Ok(id) => state.post_service.get_post_by_id(id).await?,
         Err(_) => state.post_service.get_post_by_slug(&id_or_slug).await?,
     };
-    Ok(Json(post))
+    Ok(Json(post_detail))
 }
 
 // 更新文章处理器
@@ -51,8 +51,8 @@ pub async fn update_post_handler(
     Path(id): Path<Uuid>,
     Json(payload): Json<UpdatePostPayload>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let update_post = state.post_service.update_post(id, payload).await?;
-    Ok(Json(update_post))
+    let update_post_detail = state.post_service.update_post(id, payload).await?;
+    Ok(Json(update_post_detail))
 }
 
 // 删除文章处理器

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod models;
-
 pub mod api_error;
 pub mod config;
 pub mod dtos;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -38,20 +38,24 @@ async fn main() -> Result<()> {
     tracing::info!("数据库迁移已应用。");
 
     //  -- 依赖注入 --
-    //  -- 创建 PostService 实例 ---
-    let post_repo = Arc::new(PostgresPostRepository::new(db_pool.clone()));
-    let post_repo_trait: Arc<dyn PostRepository> = post_repo;
-    let post_service = Arc::new(PostService::new(post_repo_trait));
-
     //  -- 创建 CategoryService 实例 ---
     let category_repo = Arc::new(PostgresCategoryRepository::new(db_pool.clone()));
     let category_repo_trait: Arc<dyn CategoryRepository> = category_repo;
-    let category_service = Arc::new(CategoryService::new(category_repo_trait));
+    let category_service = Arc::new(CategoryService::new(category_repo_trait.clone()));
 
     // -- 创建 TagService 实例 ----
     let tag_repo = Arc::new(PostgresTagRepository::new(db_pool.clone()));
     let tag_repo_trait: Arc<dyn TagRepository> = tag_repo;
-    let tag_service = Arc::new(TagService::new(tag_repo_trait));
+    let tag_service = Arc::new(TagService::new(tag_repo_trait.clone()));
+
+    //  -- 创建 PostService 实例 ---
+    let post_repo = Arc::new(PostgresPostRepository::new(db_pool.clone()));
+    let post_repo_trait: Arc<dyn PostRepository> = post_repo;
+    let post_service = Arc::new(PostService::new(
+        post_repo_trait.clone(),
+        category_repo_trait.clone(),
+        tag_repo_trait.clone(),
+    ));
 
     // 创建 AppState
     let app_state = AppState {

--- a/backend/src/repositories/post.rs
+++ b/backend/src/repositories/post.rs
@@ -1,10 +1,10 @@
+use crate::dtos::post::{CategoryDto, CreatePostPayload, TagDto, UpdatePostPayload};
 use crate::models::Post;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
-use crate::dtos::post::{CreatePostPayload, UpdatePostPayload};
 
 // 定义仓库操作的 trait
 #[async_trait]
@@ -23,6 +23,14 @@ pub trait PostRepository: Send + Sync {
     ) -> Result<Post>;
 
     async fn delete(&self, id: Uuid) -> Result<()>;
+
+    // 获取帖子的完整分类和标签对象
+    async fn get_categories_for_post(&self, post_id: Uuid) -> Result<Vec<CategoryDto>>;
+    async fn get_tags_for_post(&self, post_id: Uuid) -> Result<Vec<TagDto>>;
+    // 获取帖子的分类和标签IDs
+    // 暂时不实现，但作为未来获取关联信息的占位
+    // async fn get_category_ids_for_post(&self, post_id: Uuid, pool: &PgPool) -> Result<Vec<Uuid>>;
+    // async fn get_tag_ids_for_post(&self, post_id: Uuid, pool: &PgPool) -> Result<Vec<Uuid>>;
 }
 
 // Postgres的具体实现
@@ -35,6 +43,72 @@ impl PostgresPostRepository {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
+
+    // 辅助函数：在事务中管理帖子的分类关联
+    async fn manage_post_categories(
+        txn: &mut Transaction<'_, Postgres>,
+        post_id: Uuid,
+        category_ids: &Option<Vec<Uuid>>,
+        is_update: bool, // 用来区分是创建操作还是更新操作。如果是更新，会先删除该帖子的所有旧关联。
+    ) -> Result<()> {
+        if is_update {
+            // 更新时，先删除旧的关联
+            sqlx::query!("delete from post_categories where post_id = $1", post_id)
+                .execute(&mut **txn) // 使用 txn
+                .await
+                .context("Failed to delete old post categories")?;
+        }
+        if let Some(ids) = category_ids {
+            if !ids.is_empty() {
+                // 准备批量插入
+                // SQLx 的 query! 和 query_as! 不直接支持 VALUES ($1, $2), ($1, $3), ... 这样的动态多行插入
+                // 我们需要循环插入，或者构建更复杂的查询字符串 (后者不推荐，易出错且不安全)
+                // 或者使用 sqlx::QueryBuilder (更安全地构建动态查询)
+                // 为了简单起见，这里先用循环。对于大量ID，性能可能不是最优，但对于少量ID是可接受的。
+                for category_id in ids {
+                    sqlx::query!(
+                        "insert into post_categories (post_id, category_id) values ($1,$2) on conflict do nothing",
+                        post_id,
+                        category_id
+                    )
+                        .execute(&mut **txn)
+                        .await
+                        .context(format!("Failed to associate post {} with category {}",post_id,category_id))?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // 辅助函数：在事务中管理帖子的标签关联
+    async fn manage_post_tags(
+        txn: &mut Transaction<'_, Postgres>,
+        post_id: Uuid,
+        tag_ids: &Option<Vec<Uuid>>,
+        is_update: bool,
+    ) -> Result<()> {
+        if is_update {
+            sqlx::query!("delete from post_tags where post_id = $1", post_id)
+                .execute(&mut **txn)
+                .await
+                .context("Failed to delete old tags")?;
+        }
+        if let Some(ids) = tag_ids {
+            if !ids.is_empty() {
+                for tag_id in ids {
+                    sqlx::query!(
+                        "insert into post_tags (post_id, tag_id) values ($1,$2) on conflict do nothing",
+                        post_id,
+                        tag_id
+                    )
+                        .execute(&mut **txn)
+                        .await
+                        .context(format!("Failed to associate post {} with tag {}",post_id,tag_id))?;
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -42,6 +116,15 @@ impl PostRepository for PostgresPostRepository {
     async fn create(&self, payload: &CreatePostPayload, slug: &str) -> Result<Post> {
         let post_id = Uuid::new_v4();
         let now = Utc::now();
+
+        // 开始数据库事务
+        let mut txn = self
+            .pool
+            .begin()
+            .await
+            .context("Failed to begin transaction for creating post")?;
+
+        // 1. 插入帖子基本信息
         let post = sqlx::query_as!(
             Post,
             r#"
@@ -51,15 +134,33 @@ impl PostRepository for PostgresPostRepository {
             "#,
             post_id,
             slug,
-            payload.title,
-            payload.content,
+            &payload.title,
+            &payload.content,
             now,
             now,
             None::<DateTime<Utc>>
         )
-            .fetch_one(&self.pool)
+        .fetch_one(&mut *txn) // 在事务中执行
+        .await
+        .context("未能将帖子基本信息插入到posts表中")?; // 使用 ？ 和 context
+
+        // 2. 关联分类(如果提供了 category_ids)
+        // is_update is false for creation
+        Self::manage_post_categories(&mut txn, post.id, &payload.category_ids, false)
             .await
-            .context("创建 Post 记录 失败 (INSERT)")?; // 使用 ？ 和 context
+            .context("Failed to manage post categories during creation")?;
+
+        // 3. 关联标签(如果提供了 tag_ids)
+        // is_update is false for creation
+        Self::manage_post_tags(&mut txn, post.id, &payload.tag_ids, false)
+            .await
+            .context("Failed to manage post tags during creation")?;
+
+        // 提交事务
+        txn.commit()
+            .await
+            .context("Failed to commit transaction for creating post")?;
+
         Ok(post)
     }
 
@@ -82,7 +183,9 @@ impl PostRepository for PostgresPostRepository {
         let post = sqlx::query_as!(
             Post,
             r#"
-            select id,slug,title,content,created_at as "created_at!",updated_at as "updated_at!",published_at from posts where slug = $1
+            select id,slug,title,content,created_at as "created_at!",updated_at as "updated_at!",published_at 
+            from posts 
+            where slug = $1
             "#,
             slug
         )
@@ -93,7 +196,7 @@ impl PostRepository for PostgresPostRepository {
     }
 
     async fn list(&self, limit: i64, offset: i64) -> Result<(Vec<Post>, i64)> {
-        // // --- 查询当前页的帖子列表,实际中应只查询已发布的帖子 ---
+        // --- 查询当前页的帖子列表,实际中应只查询已发布的帖子 ---
         let posts = sqlx::query_as!(
             Post,
             r#"
@@ -118,9 +221,9 @@ impl PostRepository for PostgresPostRepository {
              -- WHERE published_at IS NOT NULL AND published_at <= NOW() -- 同样需要过滤
             "#
         )
-            .fetch_one(&self.pool)
-            .await
-            .context("查询帖子总数失败")?;
+        .fetch_one(&self.pool)
+        .await
+        .context("查询帖子总数失败")?;
 
         // 从结果中获取 count 值，注意类型可能需要转换
         // query! 返回的 count 通常是 i64 或 Decimal，取决于数据库和 COUNT(*) 的结果
@@ -136,12 +239,12 @@ impl PostRepository for PostgresPostRepository {
         payload: &UpdatePostPayload,
         new_slug_opt: Option<&str>,
     ) -> Result<Post> {
-        tracing::info!(
-            "[REPO UPDATE DEBUG] Test: {}, ID: {}, Payload published_at: {:?}",
-            "test_update_post_unpublish (expected)", // 手动标记一下我们关心的测试
-            id,
-            payload.published_at
-        );
+        // 开启数据库事务
+        let mut txn = self
+            .pool
+            .begin()
+            .await
+            .context("Failed to begin transaction for updating post")?;
 
         // 1. 获取当前帖子数据 current_post,准备更新值的逻辑
         let current_post = self
@@ -150,12 +253,7 @@ impl PostRepository for PostgresPostRepository {
             .context(format!("更新操作：获取 Post (id: {})", id))?
             .ok_or_else(|| anyhow::anyhow!("更新目标 Post (id: {}) 未找到，无法继续", id))?;
 
-        tracing::info!(
-            "[REPO UPDATE DEBUG] Fetched current_post.published_at: {:?}",
-            current_post.published_at
-        );
-
-        // 2.准备要更新的字段值
+        // 准备要更新的字段值
         // 对于 title, content, slug，如果 payload 中是 None，则使用 current_post 的旧值
         let title_to_update = payload.title.as_deref().unwrap_or(&current_post.title);
         let content_to_update = payload.content.as_deref().unwrap_or(&current_post.content);
@@ -172,22 +270,8 @@ impl PostRepository for PostgresPostRepository {
         // 总是更新 updated_at
         let now = Utc::now();
 
-        /*let published_at_to_update = match payload.published_at {
-            Some(Some(new_val)) => {
-                tracing::info!("[REPO UPDATE DEBUG] Matched payload.published_at: Some(Some(val)) -> Some(new_val)");
-                // 意图A: 设置为特定时间
-                Some(new_val)
-            }
-            Some(None) => {
-                tracing::info!("[REPO UPDATE DEBUG] Matched payload.published_at: Some(None) -> None");
-                None // 意图B: 设置为 NULL (撤稿)
-            }
-            None => {
-                tracing::info!("[REPO UPDATE DEBUG] Matched payload.published_at: None -> current_post.published_at ({:?})", current_post.published_at);
-                current_post.published_at // 意图C: 保持不变 (payload 中未提供此字段)
-            }
-        };*/
         let published_at_to_update;
+
         if payload.unpublish {
             published_at_to_update = None;
         } else if let Some(new_published_val) = payload.published_at {
@@ -196,15 +280,13 @@ impl PostRepository for PostgresPostRepository {
             published_at_to_update = current_post.published_at;
         }
 
-        tracing::info!(
-            "[REPO UPDATE DEBUG] Final published_at_to_update for SQL: {:?}",
-            published_at_to_update
-        );
-
+        // 2. 更新帖子基本信息
         let updated_post_from_db = sqlx::query_as!(
             Post,
             r#"
-            update posts set title = $1,content = $2,slug = $3,updated_at = $4,published_at = $5 where id = $6
+            update posts
+            set title = $1,content = $2,slug = $3,updated_at = $4,published_at = $5
+            where id = $6
             returning id, slug, title, content, created_at AS "created_at!", updated_at AS "updated_at!", published_at
             "#,
             title_to_update,
@@ -214,19 +296,44 @@ impl PostRepository for PostgresPostRepository {
             published_at_to_update,
             id
         )
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *txn)
             .await
             .context(format!("数据库层面更新 Post (id: {}) 失败", id))?;
 
-        tracing::info!(
-            "[REPO UPDATE DEBUG] Post returned from DB - published_at: {:?}",
-            updated_post_from_db.published_at
-        );
+        // 3. 更新分类关联（如果payload中提供了category_ids）
+        // is_update is true
+        if payload.category_ids.is_some() {
+            // 只有当 payload 中明确包含 category_ids 时才操作
+            Self::manage_post_categories(
+                &mut txn,
+                updated_post_from_db.id,
+                &payload.category_ids,
+                true,
+            )
+            .await
+            .context("Failed to manage post categories during update")?;
+        }
+
+        // 4. 更新标签关联（如果 payload 中提供了 tag_ids)
+        // is_update is true
+        if payload.tag_ids.is_some() {
+            // 只有当 payload 中明确包含 tag_ids 时才操作
+            Self::manage_post_tags(&mut txn, updated_post_from_db.id, &payload.tag_ids, true)
+                .await
+                .context("Failed to manage post tags during update")?;
+        }
+
+        // 提交事务
+        txn.commit()
+            .await
+            .context("Failed to commit transaction for updating post")?;
 
         Ok(updated_post_from_db)
     }
 
     async fn delete(&self, id: Uuid) -> Result<()> {
+        // 删除帖子时，由于 post_categories 和 post_tags 表设置了 ON DELETE CASCADE,
+        // 中间表的关联记录会自动被删除。所以这里只需要删除 posts 表的记录。
         let result = sqlx::query!("delete from posts where id = $1", id)
             .execute(&self.pool)
             .await
@@ -236,5 +343,44 @@ impl PostRepository for PostgresPostRepository {
             anyhow::bail!("尝试删除 Post (id: {}) 时未找到记录", id);
         }
         Ok(())
+    }
+
+    // 实现获取帖子关联的分类和标签的方法
+    async fn get_categories_for_post(&self, post_id: Uuid) -> Result<Vec<CategoryDto>> {
+        let categories = sqlx::query_as!(
+            CategoryDto,
+            r#"
+            select c.id,c.name,c.slug
+            from categories c
+            inner join post_categories pc on c.id = pc.category_id
+            where pc.post_id = $1
+            order by c.name
+            "#,
+            post_id
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context(format!("Failed to fetch categories for post {}", post_id))?;
+
+        Ok(categories)
+    }
+
+    async fn get_tags_for_post(&self, post_id: Uuid) -> Result<Vec<TagDto>> {
+        let tags = sqlx::query_as!(
+            TagDto,
+            r#"
+            select t.id,t.name,t.slug
+            from tags t
+            inner join post_tags pt on t.id = pt.tag_id
+            where pt.post_id = $1
+            order by t.name
+            "#,
+            post_id
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context(format!("Failed to fetch tags for post {}", post_id))?;
+
+        Ok(tags)
     }
 }

--- a/backend/src/services/post.rs
+++ b/backend/src/services/post.rs
@@ -1,8 +1,7 @@
-use crate::dtos::post::{CreatePostPayload, UpdatePostPayload};
+use crate::dtos::post::{CreatePostPayload, PostDetailDto, UpdatePostPayload};
 use crate::dtos::{PaginatedResponse, Pagination};
-use crate::models::Post;
-use crate::repositories::PostRepository;
-use anyhow::{anyhow, Context, Result};
+use crate::repositories::{CategoryRepository, PostRepository, TagRepository};
+use anyhow::{anyhow, Context, Ok, Result};
 use slug::slugify;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -11,14 +10,48 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct PostService {
     repo: Arc<dyn PostRepository>,
+    category_repo: Arc<dyn CategoryRepository>,
+    tag_repo: Arc<dyn TagRepository>,
 }
 
 impl PostService {
-    pub fn new(repo: Arc<dyn PostRepository>) -> Self {
-        Self { repo }
+    pub fn new(
+        repo: Arc<dyn PostRepository>,
+        category_repo: Arc<dyn CategoryRepository>,
+        tag_repo: Arc<dyn TagRepository>,
+    ) -> Self {
+        Self {
+            repo,
+            category_repo,
+            tag_repo,
+        }
     }
 
-    pub async fn create_post(&self, payload: CreatePostPayload) -> Result<Post> {
+    // 辅助函数：验证分类 IDs 是否都有效
+    async fn validate_category_ids(&self, category_ids: &Option<Vec<Uuid>>) -> Result<()> {
+        if let Some(ids) = category_ids {
+            for id in ids {
+                if self.category_repo.get_by_id(*id).await?.is_none() {
+                    return Err(anyhow!("无效的分类 ID：{}", id));
+                }
+            }
+        }
+        Ok(())
+    }
+    // 辅助函数：验证标签 IDs 是否都有效
+    async fn validate_tag_ids(&self, tag_ids: &Option<Vec<Uuid>>) -> Result<()> {
+        if let Some(ids) = tag_ids {
+            for id in ids {
+                if self.tag_repo.get_by_id(*id).await?.is_none() {
+                    return Err(anyhow!("无效的标签 ID：{}", id));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // 创建帖子，并返回包含完整关联信息的 PostDetailDto
+    pub async fn create_post(&self, payload: CreatePostPayload) -> Result<PostDetailDto> {
         if payload.title.trim().is_empty() {
             // 使用 anyhow！ 宏创建错误
             return Err(anyhow!("标题不能为空"));
@@ -26,63 +59,205 @@ impl PostService {
         if payload.content.trim().is_empty() {
             return Err(anyhow!("内容不能为空"));
         }
+        // 验证 category_ids 和 tag_ids
+        self.validate_category_ids(&payload.category_ids)
+            .await
+            .context("创建帖子时验证分类ID失败")?;
+        self.validate_tag_ids(&payload.tag_ids)
+            .await
+            .context("创建帖子时验证标签ID失败")?;
+
         // 根据文章 title 生成 slug
         let slug = slugify(&payload.title);
 
-        // 调用仓库，使用 ? 和 context
-        let post = self
+        // 调用仓库，repo.create 返回基本的 Post 对象，它已经处理了关联表的写入
+        let created_post_basic = self
             .repo
             .create(&payload, &slug)
             .await
-            .context("Service未能创建帖子")?;
+            .context("Service未能创建帖子基本信息及关联")?;
 
-        // 在 anyhow 中，处理唯一约束冲突需要检查错误的根源 (downcasting)
-        // 但更简单的方式是让它作为普通的 anyhow::Error 传递上去
-        // 如果需要特定处理，会增加复杂度
+        // 创建成功后，获取完整的 PostDetailDto
+        let categories = self
+            .repo
+            .get_categories_for_post(created_post_basic.id)
+            .await
+            .context(format!(
+                "获取新创建帖子 {} 的分类失败",
+                created_post_basic.id
+            ))?;
+        let tags = self
+            .repo
+            .get_tags_for_post(created_post_basic.id)
+            .await
+            .context(format!(
+                "获取新创建帖子 {} 的标签失败",
+                created_post_basic.id
+            ))?;
 
-        Ok(post)
+        let post_detail_dto = PostDetailDto {
+            id: created_post_basic.id,
+            slug: created_post_basic.slug,
+            title: created_post_basic.title,
+            content: created_post_basic.content,
+            created_at: created_post_basic.created_at,
+            updated_at: created_post_basic.created_at,
+            published_at: created_post_basic.published_at,
+            categories: if categories.is_empty() {
+                None
+            } else {
+                Some(categories)
+            },
+            tags: if tags.is_empty() { None } else { Some(tags) },
+        };
+        Ok(post_detail_dto)
     }
 
-    pub async fn get_post_by_id(&self, id: Uuid) -> Result<Post> {
-        let post_option = self
+    // 获取单个帖子详情，返回 PostDetailDto
+    pub async fn get_post_by_id(&self, id: Uuid) -> Result<PostDetailDto> {
+        let post = self
             .repo
             .get_by_id(id)
             .await
-            .context(format!("Service未能通过id: ({})获取帖子", id))?;
+            .context(format!("Service未能通过id: ({})获取帖子基本信息", id))?
+            .ok_or_else(|| anyhow!("未找到 ID 为 {} 的帖子", id))?;
 
-        // 将 Option<Post> 转换为 Result<Post, anyhow::Error>
-        post_option.ok_or_else(|| anyhow!("未找到id为{}的帖子", id))
+        let categories = self
+            .repo
+            .get_categories_for_post(post.id)
+            .await
+            .context(format!("获取新创建帖子 {} 的分类失败", post.id))?;
+        let tags = self
+            .repo
+            .get_tags_for_post(post.id)
+            .await
+            .context(format!("获取新创建帖子 {} 的标签失败", post.id))?;
+
+        let post_detail_dto = PostDetailDto {
+            id: post.id,
+            slug: post.slug,
+            title: post.title,
+            content: post.content,
+            created_at: post.created_at,
+            updated_at: post.created_at,
+            published_at: post.published_at,
+            categories: if categories.is_empty() {
+                None
+            } else {
+                Some(categories)
+            },
+            tags: if tags.is_empty() { None } else { Some(tags) },
+        };
+        Ok(post_detail_dto)
     }
 
-    pub async fn get_post_by_slug(&self, slug: &str) -> Result<Post> {
-        let post_option = self
+    // 获取单个帖子详情（通过slug），返回 PostDetailDto
+    pub async fn get_post_by_slug(&self, slug: &str) -> Result<PostDetailDto> {
+        let post = self
             .repo
             .get_by_slug(slug)
             .await
-            .context(format!("Service未能通过 slug ({}) 获取帖子", slug))?;
-        post_option.ok_or_else(|| anyhow!("未找到 slug 为 '{}' 的帖子", slug))
+            .context(format!("Service未能通过 slug ({}) 获取帖子基本信息", slug))?
+            .ok_or_else(|| anyhow!("未找到 slug 为 '{}' 的帖子", slug))?;
+
+        let categories = self
+            .repo
+            .get_categories_for_post(post.id)
+            .await
+            .context(format!("获取新创建帖子 {} 的分类失败", post.id))?;
+        let tags = self
+            .repo
+            .get_tags_for_post(post.id)
+            .await
+            .context(format!("获取新创建帖子 {} 的标签失败", post.id))?;
+
+        let post_detail_dto = PostDetailDto {
+            id: post.id,
+            slug: post.slug,
+            title: post.title,
+            content: post.content,
+            created_at: post.created_at,
+            updated_at: post.created_at,
+            published_at: post.published_at,
+            categories: if categories.is_empty() {
+                None
+            } else {
+                Some(categories)
+            },
+            tags: if tags.is_empty() { None } else { Some(tags) },
+        };
+        Ok(post_detail_dto)
     }
 
-    pub async fn list_posts(&self, pagination: Pagination) -> Result<PaginatedResponse<Post>> {
+    // 获取帖子列表，返回包含 PostDetailDto 的分页响应
+    pub async fn list_posts(
+        &self,
+        pagination: Pagination,
+    ) -> Result<PaginatedResponse<PostDetailDto>> {
         // 从 Pagination DTO 获取验证过的分页参数
         let limit = pagination.limit();
         let offset = pagination.offset();
         let page = pagination.page();
         let page_size = pagination.page_size();
 
-        // 调用仓库方法
+        // 1. 获取基本的帖子列表
         let (posts, total_items) = self
             .repo
             .list(limit, offset)
             .await
-            .context("Service 未能获取分页的帖子列表")?;
+            .context("Service 未能获取分页的帖子列表(基本信息）")?;
 
-        let response = PaginatedResponse::new(posts, total_items, page, page_size);
+        // 2. 为每个帖子获取其关联的分类和标签 (N+1 查询问题警告)
+        let mut post_details_list = Vec::with_capacity(posts.len());
+
+        for post in posts {
+            let categories = self
+                .repo
+                .get_categories_for_post(post.id)
+                .await
+                .context(format!("获取新创建帖子 {} 的分类失败", post.id))?;
+            let tags = self
+                .repo
+                .get_tags_for_post(post.id)
+                .await
+                .context(format!("获取新创建帖子 {} 的标签失败", post.id))?;
+            let post_detail_dto = PostDetailDto {
+                id: post.id,
+                slug: post.slug,
+                title: post.title,
+                content: post.content,
+                created_at: post.created_at,
+                updated_at: post.created_at,
+                published_at: post.published_at,
+                categories: if categories.is_empty() {
+                    None
+                } else {
+                    Some(categories)
+                },
+                tags: if tags.is_empty() { None } else { Some(tags) },
+            };
+            post_details_list.push(post_detail_dto);
+        }
+
+        let response = PaginatedResponse::new(post_details_list, total_items, page, page_size);
 
         Ok(response)
     }
 
-    pub async fn update_post(&self, id: Uuid, payload: UpdatePostPayload) -> Result<Post> {
+    // 更新帖子，并返回包含完整关联信息的 PostDetailDto
+    pub async fn update_post(&self, id: Uuid, payload: UpdatePostPayload) -> Result<PostDetailDto> {
+        // 验证 category_ids 和 tag_ids (如果提供了)
+        if payload.category_ids.is_some() {
+            self.validate_category_ids(&payload.category_ids)
+                .await
+                .context("更新帖子时验证分类ID失败")?;
+        }
+        if payload.tag_ids.is_some() {
+            self.validate_tag_ids(&payload.tag_ids)
+                .await
+                .context("更新帖子时验证标签ID失败")?;
+        }
+
         let maybe_new_slug = if let Some(new_title) = &payload.title {
             if !new_title.trim().is_empty() {
                 Some(slugify(new_title))
@@ -92,10 +267,43 @@ impl PostService {
         } else {
             None
         };
-        self.repo
+        // repo.update 返回基本的 Post 对象，它已经处理了关联表的更新
+        let post = self
+            .repo
             .update(id, &payload, maybe_new_slug.as_deref())
             .await
-            .context(format!("Service 未能更新帖子 (id: {})", id))
+            .context(format!(
+                "Service 未能更新帖子 (id: {}) 的基本信息和关联",
+                id
+            ))?;
+        // 更新成功后，获取完整的 PostDetailDto
+        let categories = self
+            .repo
+            .get_categories_for_post(post.id)
+            .await
+            .context(format!("获取更新后帖子 {} 的分类失败", post.id))?;
+        let tags = self
+            .repo
+            .get_tags_for_post(post.id)
+            .await
+            .context(format!("获取更新后帖子 {} 的标签失败", post.id))?;
+        let post_detail_dto = PostDetailDto {
+            id: post.id,
+            slug: post.slug,
+            title: post.title,
+            content: post.content,
+            created_at: post.created_at,
+            updated_at: post.created_at,
+            published_at: post.published_at,
+            categories: if categories.is_empty() {
+                None
+            } else {
+                Some(categories)
+            },
+            tags: if tags.is_empty() { None } else { Some(tags) },
+        };
+
+        Ok(post_detail_dto)
     }
 
     pub async fn delete_post(&self, id: Uuid) -> Result<()> {

--- a/backend/tests/post_api_tests.rs
+++ b/backend/tests/post_api_tests.rs
@@ -305,6 +305,8 @@ async fn test_create_post_valid_payload(pool: PgPool) -> Result<()> {
     let payload = CreatePostPayload {
         title: "新帖子标题".to_string(),
         content: "这是新帖子的内容。".to_string(),
+        category_ids: None,
+        tag_ids: None
     };
 
     let request = Request::builder()
@@ -363,6 +365,8 @@ async fn test_create_post_empty_title(pool: PgPool) -> Result<()> {
     let payload = CreatePostPayload {
         title: "".to_string(),
         content: "一些内容。".to_string(),
+        category_ids: None,
+        tag_ids: None
     };
 
     let request = Request::builder()
@@ -393,6 +397,8 @@ async fn test_create_post_slug_conflict(pool: PgPool) -> Result<()> {
     let payload_conflict = CreatePostPayload {
         title: title.to_string(),
         content: "不同的内容，但标题相同".to_string(),
+        category_ids: None,
+        tag_ids: None,
     };
 
     let request_conflict = Request::builder()
@@ -561,6 +567,8 @@ async fn test_update_post_full_success(pool: PgPool) -> Result<()> {
         slug: None,
         published_at: Some(now_for_publish), // 显示发布
         unpublish: false,                    // 明确不是撤稿 (或者依赖默认值)
+        category_ids: None,
+        tag_ids: None,
     };
 
     let request_uri = format!("/posts/{}", original_post.id);
@@ -628,6 +636,8 @@ async fn test_update_post_partial_title_only(pool: PgPool) -> Result<()> {
         slug: None,         // 不显式更新 slug
         published_at: None, // 不改变发布状态
         unpublish: false,   // 明确不是撤稿 (或者依赖默认值)
+        category_ids: None,
+        tag_ids: None
     };
 
     let request_uri = format!("/posts/{}", original_post.id);
@@ -677,6 +687,8 @@ async fn test_update_post_unpublish(pool: PgPool) -> Result<()> {
         slug: None,
         published_at: None, // 显式设置为 null，即撤稿
         unpublish: true,    // 明确不是撤稿 (或者依赖默认值)
+        category_ids: None,
+        tag_ids: None,
     };
 
     let request_uri = format!("/posts/{}", original_post.id);
@@ -741,6 +753,8 @@ async fn test_update_post_invalid_payload_empty_title(pool: PgPool) -> Result<()
         slug: None,
         published_at: None,
         unpublish: false, // 明确不是撤稿 (或者依赖默认值)
+        category_ids: None,
+        tag_ids: None
     };
 
     let request_uri = format!("/posts/{}", original_post.id);


### PR DESCRIPTION
- 添加了数据库迁移以创建 post_categories 和 post_tags 中间表。
- 更新了 DTO、Repository、Service 和 Handler 层以支持帖子与分类/标签的多对多关联。
- 创建/更新/获取帖子 API 现在能够处理和展示关联的分类与标签信息 (使用 PostDetailDto)。
- 帖子列表 API 现在返回包含每个帖子关联信息的 PostDetailDto 列表。
- 更新并扩展了 post_api_tests.rs 中的集成测试，覆盖了新的关联功能